### PR TITLE
Fix Instrumentation Job from Android CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v2
 
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
 
@@ -67,16 +72,12 @@ jobs:
             ~/.android/adb*
           key: avd-30
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 30
+          arch: 'x86_64'
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -86,6 +87,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 30
+          arch: 'x86_64'
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -55,11 +55,6 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
 
@@ -72,13 +67,13 @@ jobs:
             ~/.android/adb*
           key: avd-30
 
-      - name: create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
 
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 30


### PR DESCRIPTION
The problem was just a missing parameter for the architecture.

Without specifying, it grabs x86, which leads to no system image found.

After specifying to x86_64, it just runs flawlessly.